### PR TITLE
feat: install and set default python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ RUN yum -y update \
     initscripts \
     iproute \
     openssl \
+    python3.11 \
     sudo \
     which \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && yum clean all
+    && yum clean all \
+    # set python 3.11 as default
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
 
 # selectively remove systemd targets -- See https://hub.docker.com/_/centos/
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \


### PR DESCRIPTION
this keeps python3.9 installed on the image, but adds 3.11 and sets it to the default for `python3` calls