### PR TITLE
Revert "feat: install set default python to 3.11"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,10 @@ RUN yum -y update \
     initscripts \
     iproute \
     openssl \
-    python3.11 \
     sudo \
     which \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && yum clean all \
-    # set python 3.11 as default
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
+    && yum clean all
 
 # selectively remove systemd targets -- See https://hub.docker.com/_/centos/
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \


### PR DESCRIPTION
This reverts commit 05a1280b401ed457805e76ecd49bfd22718c0986. No need for 3.11 on target node, incorrectly read the [ansible-core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)